### PR TITLE
Update zaptool.rb

### DIFF
--- a/zapptool.rb
+++ b/zapptool.rb
@@ -2,10 +2,10 @@ class Zapptool < Formula
   desc "Fast configuration tool for modular app"
   homepage "https://github.com/applicaster/ZappTool"
   url "git@github.com:applicaster/ZappTool.git", :using => :git,
-                                                 :tag => "v1.1.1"
+                                                 :tag => "v1.1.2"
   head "https://github.com/applicaster/ZappTool.git"
 
-  version "1.1.1"
+  version "1.1.2"
   depends_on "ImageMagick" => :build
   depends_on :xcode => "9.0"
 


### PR DESCRIPTION
Update zaptool.rb to use version 1.1.2 that includes the keychain-sharing functionality.