### PR TITLE
Zappifest 0.38.0

### DIFF
--- a/zappifest.rb
+++ b/zappifest.rb
@@ -57,6 +57,7 @@ class Zappifest < Formula
       "lib/react_native_questions_helper.rb",
       "lib/react_native_npm_questions_helper.rb",
       "lib/version.rb",
+      "lib/version_helper.rb"
       "lib/plugin_version.rb",
       "lib/plugin.rb",
       "lib/plugin_base.rb",

--- a/zappifest.rb
+++ b/zappifest.rb
@@ -1,9 +1,9 @@
 class Zappifest < Formula
   desc "Tool to generate Zapp plugin manifest"
   homepage "https://github.com/applicaster/zappifest"
-  url "https://github.com/applicaster/zappifest/archive/0.37.4.tar.gz"
-  version "0.37.4"
-  sha256 "c3fb1d1376dcab11af6695ef34c8ef6ca07c7bd8b06cad95fca17e6093841d32"
+  url "https://github.com/applicaster/zappifest/archive/0.38.0.tar.gz"
+  version "0.38.0"
+  sha256 "f8205c5c641887195fcb1041fe6552ac5937dc5373cbe20603b371d115929a8c"
 
   resource "commander" do
     url "https://rubygems.org/gems/commander-4.4.0.gem"

--- a/zappifest.rb
+++ b/zappifest.rb
@@ -30,6 +30,11 @@ class Zappifest < Formula
     sha256 "1cb639228bf9f2e98543f866e94e64872631d7b6c8b2a5565289175405e1e0af"
   end
 
+  resource "versionomy" do
+    url "https://rubygems.org/gems/versionomy-0.5.0.gem"
+    sha256 "636c8f9174c884034d1b24354a479c579b32e7839d897729b97e079aff251444"
+  end
+
   def install
     resources.each do |r|
       r.verify_download_integrity(r.fetch)


### PR DESCRIPTION
This PR updates the homebrew tap with zappifest 0.38.0