### PR TITLE
update zappifest to 0.38.4

### DIFF
--- a/zappifest.rb
+++ b/zappifest.rb
@@ -1,9 +1,9 @@
 class Zappifest < Formula
   desc "Tool to generate Zapp plugin manifest"
   homepage "https://github.com/applicaster/zappifest"
-  url "https://github.com/applicaster/zappifest/archive/0.38.3.tar.gz"
-  version "0.38.3"
-  sha256 "1370ef5f36a550a884fcac08792d974e4e1efecfe0e10948612868c3c500fdfa"
+  url "https://github.com/applicaster/zappifest/archive/0.38.4.tar.gz"
+  version "0.38.4"
+  sha256 "8fdf8402bd5d822df369092ada4b85afd5ad68b6e74d7a5eac94f197e7e772c4"
 
   resource "commander" do
     url "https://rubygems.org/gems/commander-4.4.0.gem"


### PR DESCRIPTION
This PR updates zappifest to 0.38.4 https://github.com/applicaster/zappifest/releases/tag/0.38.4