### PR TITLE
Update zappifest 0.40.0

### DIFF
--- a/zappifest.rb
+++ b/zappifest.rb
@@ -2,8 +2,8 @@ class Zappifest < Formula
   desc "Tool to generate Zapp plugin manifest"
   homepage "https://github.com/applicaster/zappifest"
   url "https://github.com/applicaster/zappifest/archive/0.40.0.tar.gz"
-  version "0.39.0"
-  sha256 "1f7ebc1e0000f8e5d23bc03fe747e9959078e2fe1591a651dd91a05fca0d57b1"
+  version "0.40.0"
+  sha256 "5e9fbc61d5e262396738b7635c14853b03b5404fe696b3a72a153e8e69dec6eb"
 
   resource "commander" do
     url "https://rubygems.org/gems/commander-4.4.0.gem"

--- a/zappifest.rb
+++ b/zappifest.rb
@@ -1,7 +1,7 @@
 class Zappifest < Formula
   desc "Tool to generate Zapp plugin manifest"
   homepage "https://github.com/applicaster/zappifest"
-  url "https://github.com/applicaster/zappifest/archive/0.39.0.tar.gz"
+  url "https://github.com/applicaster/zappifest/archive/0.40.0.tar.gz"
   version "0.39.0"
   sha256 "1f7ebc1e0000f8e5d23bc03fe747e9959078e2fe1591a651dd91a05fca0d57b1"
 
@@ -53,6 +53,7 @@ class Zappifest < Formula
       "lib/api_questions_helper.rb",
       "lib/custom_fields_questions_helper.rb",
       "lib/data_source_provider_questions_helper.rb",
+      "lib/navigation_plugins_questions_helper.rb",
       "lib/default_questions_helper.rb",
       "lib/react_native_questions_helper.rb",
       "lib/react_native_npm_questions_helper.rb",


### PR DESCRIPTION
This PR updates zappifest to `0.40.0` with sha 5e9fbc61d5e262396738b7635c14853b03b5404fe696b3a72a153e8e69dec6eb

![image](https://user-images.githubusercontent.com/15126070/37716562-18ab3dc8-2d1f-11e8-9527-fb030642be09.png)
