### PR TITLE
update zappifest 0.60.0

### DIFF
--- a/zappifest.rb
+++ b/zappifest.rb
@@ -1,9 +1,9 @@
 class Zappifest < Formula
   desc "Tool to generate Zapp plugin manifest"
   homepage "https://github.com/applicaster/zappifest"
-  url "https://github.com/applicaster/zappifest/archive/0.59.0.tar.gz"
-  version "0.59.0"
-  sha256 "6869fadb9cdfdf166143be5c9e0caea6ce1acc75431e924d12eccdb1f563a714"
+  url "https://github.com/applicaster/zappifest/archive/0.60.0.tar.gz"
+  version "0.60.0"
+  sha256 "2501e975f9fc94762e07bd41ceb9860c1bc3bb7bd643c72f9f8631f14431d346"
 
   resource "commander" do
     url "https://rubygems.org/gems/commander-4.4.0.gem"


### PR DESCRIPTION
Update for Zappifest 60, adding player_overlay plugin type